### PR TITLE
add info about `trash` command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,15 @@ $ npm install --save trash
 ```
 
 
+## CLI
+
+To install the command `trash`, run:
+
+```
+$ npm install --global trash-cli
+```
+
+
 ## Usage
 
 ```js


### PR DESCRIPTION
I accidentally globally installed `trash` at first and then realized there's a separate project for the CLI.

The `trash-cli` project also seems to be much less popular than this one, so it probably makes sense to have a shortcut like this in the README.