### PR TITLE
Checking for paths.length after filtering

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-* text=auto
+* text eol=lf
 lib/osx-trash binary
 lib/win-trash.exe binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-* text eol=lf
+*.js text eol=lf
 lib/osx-trash binary
 lib/win-trash.exe binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+* text=auto
 *.js text eol=lf
 lib/osx-trash binary
 lib/win-trash.exe binary

--- a/index.js
+++ b/index.js
@@ -8,10 +8,6 @@ module.exports = function (paths) {
 		return Promise.reject(new TypeError('Expected an array'));
 	}
 
-	if (paths.length === 0) {
-		return Promise.resolve();
-	}
-
 	paths = paths.map(function (x) {
 		return String(x);
 	});
@@ -23,6 +19,10 @@ module.exports = function (paths) {
 	}).filter(function (x) {
 		return pathExists.sync(x);
 	});
+
+	if (paths.length === 0) {
+		return Promise.resolve();
+	}
 
 	switch (process.platform) {
 		case 'darwin': return require('./lib/osx')(paths);

--- a/index.js
+++ b/index.js
@@ -8,9 +8,7 @@ module.exports = function (paths) {
 		return Promise.reject(new TypeError('Expected an array'));
 	}
 
-	paths = paths.map(function (x) {
-		return String(x);
-	});
+	paths = paths.map(String);
 
 	paths = globby.sync(paths, {nonull: true});
 

--- a/index.js
+++ b/index.js
@@ -3,20 +3,19 @@ var path = require('path');
 var pathExists = require('path-exists');
 var globby = require('globby');
 
+// A resolve that does not accept variadic arguments so it can be used with map.
+function resolvePath(x) {
+	return path.resolve(x);
+}
+
 module.exports = function (paths) {
 	if (!Array.isArray(paths)) {
 		return Promise.reject(new TypeError('Expected an array'));
 	}
 
-	paths = paths.map(String);
-
-	paths = globby.sync(paths, {nonull: true});
-
-	paths = paths.map(function (x) {
-		return path.resolve(x);
-	}).filter(function (x) {
-		return pathExists.sync(x);
-	});
+	paths = globby.sync(paths.map(String), {nonull: true})
+		.map(resolvePath)
+		.filter(pathExists.sync);
 
 	if (paths.length === 0) {
 		return Promise.resolve();

--- a/index.js
+++ b/index.js
@@ -3,18 +3,15 @@ var path = require('path');
 var pathExists = require('path-exists');
 var globby = require('globby');
 
-// A resolve that does not accept variadic arguments so it can be used with map.
-function resolvePath(x) {
-	return path.resolve(x);
-}
-
 module.exports = function (paths) {
 	if (!Array.isArray(paths)) {
 		return Promise.reject(new TypeError('Expected an array'));
 	}
 
 	paths = globby.sync(paths.map(String), {nonull: true})
-		.map(resolvePath)
+		.map(function (x) {
+			return path.resolve(x);
+		})
 		.filter(pathExists.sync);
 
 	if (paths.length === 0) {

--- a/index.js
+++ b/index.js
@@ -24,13 +24,9 @@ module.exports = function (paths) {
 		return pathExists.sync(x);
 	});
 
-	if (process.platform === 'darwin') {
-		return require('./lib/osx')(paths);
+	switch (process.platform) {
+		case 'darwin': return require('./lib/osx')(paths);
+		case 'win32': return require('./lib/win')(paths);
+		default: return require('./lib/linux')(paths);
 	}
-
-	if (process.platform === 'win32') {
-		return require('./lib/win')(paths);
-	}
-
-	return require('./lib/linux')(paths);
 };


### PR DESCRIPTION
Hey @sindresorhus, 

I'm not sure if the paths.length === 0 check is before the filter(fileExist) check on purpose but to me it makes sense to put it after the filter. 

If I want a file to be removed but it doesn't exist in the first place then that is perfectly fine with me. There shouldn't be an error (which the windows binary yields). 

Also I set the line endings to LF in the .gitattributes file and made some code simplifications (at least I think so). 

Let me know what you think :)