### PR TITLE
Add option to disable globbing

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,10 @@ const macos = require('./lib/macos');
 const linux = require('./lib/linux');
 const win = require('./lib/win');
 
-module.exports = iterable => {
-	iterable = typeof iterable === 'string' ? [iterable] : iterable;
-	const paths = globby.sync(Array.from(iterable).map(String), {nonull: true})
+module.exports = (iterable, opts) => {
+	iterable = Array.from(typeof iterable === 'string' ? [iterable] : iterable).map(String);
+	opts = Object.assign({glob: true}, opts);
+	const paths = (opts.glob === false ? iterable : globby.sync(iterable, {nonull: true}))
 		.map(x => path.resolve(x))
 		.filter(pathExists.sync);
 

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ Accepts paths and [glob patterns](https://github.com/sindresorhus/globby#globbin
 Type: `boolean`<br>
 Default: `true`
 
-Flag to disable globbing.
+Whether to enable globbing when matching file paths.
 
 ## CLI
 

--- a/readme.md
+++ b/readme.md
@@ -26,9 +26,10 @@ trash(['*.png', '!rainbow.png']).then(() => {
 });
 ```
 
+
 ## API
 
-### trash(input)
+### trash(input, [options])
 
 Returns a `Promise`.
 
@@ -38,6 +39,14 @@ Type: `Iterable<string>`
 
 Accepts paths and [glob patterns](https://github.com/sindresorhus/globby#globbing-patterns).
 
+#### options
+
+##### glob
+
+Type: `boolean`<br>
+Default: `true`
+
+Flag to disable globbing.
 
 ## CLI
 

--- a/test.js
+++ b/test.js
@@ -48,6 +48,16 @@ test('glob', async t => {
 	t.true(pathExists.sync('fixture.png'));
 });
 
+test('no glob', async t => {
+	fs.writeFileSync('fixture-noglob*.js', '');
+	fs.writeFileSync('fixture-noglob1.js', '');
+
+	await m(['fixture-noglob*.js'], {glob: false});
+
+	t.false(pathExists.sync('fixture-noglob*.js'));
+	t.true(pathExists.sync('fixture-noglob1.js'));
+});
+
 test('string pattern', async t => {
 	fs.writeFileSync('a', '');
 	fs.writeFileSync('b', '');


### PR DESCRIPTION
Fixes #60 

This PR adds support for disabling glob support. It expects a second, optional argument `opts` with a `boolean` property `glob` set to `false` to disable the glob support. It is fully backwards compatible because the default behaviour is to glob, except if `opts` was passed and `opts.glob` equals `false`.

```javascript
// only delete the file named "*.png" and nothing else
trash(['*.png'], { glob: false })
```