### PR TITLE
Use `fs.lstatSync` instead of `fs.existsSync` to handle broken symlinks

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = (iterable, opts) => {
 
 	const paths = (opts.glob === false ? iterable : globby.sync(iterable, {nonull: true}))
 		.map(x => path.resolve(x))
-		.filter(fs.existsSync);
+		.filter(fs.lstatSync);
 
 	if (paths.length === 0) {
 		return Promise.resolve();

--- a/test.js
+++ b/test.js
@@ -101,6 +101,25 @@ test('directories', async t => {
 	t.false(fs.existsSync(321));
 });
 
+test('symlinks', async t => {
+	fs.writeFileSync('aaa', '');
+	fs.symlinkSync('aaa', 'bbb');
+	fs.symlinkSync('ddd', 'ccc');
+
+	t.truthy(fs.lstatSync('aaa'));
+	t.truthy(fs.lstatSync('bbb'));
+	t.truthy(fs.lstatSync('ccc'));
+
+	await m([
+		'bbb',
+		'ccc'
+	]);
+
+	t.truthy(fs.lstatSync('aaa'));
+	t.throws(() => fs.lstatSync('bbb'));
+	t.throws(() => fs.lstatSync('ccc'));
+});
+
 if (process.platform === 'linux') {
 	test('create trashinfo', async t => {
 		t.plan(1);


### PR DESCRIPTION
Fixes #63 