### PR TITLE
Handle a lot of files on Linux

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -1,9 +1,11 @@
 'use strict';
+const os = require('os');
 const path = require('path');
 const fsExtra = require('fs-extra');
 const pify = require('pify');
 const uuid = require('uuid');
 const xdgTrashdir = require('xdg-trashdir');
+const pMap = require('p-map');
 
 const fs = pify(fsExtra);
 
@@ -28,4 +30,4 @@ DeletionDate=${(new Date()).toISOString()}
 	});
 }
 
-module.exports = paths => Promise.all(paths.map(trash));
+module.exports = paths => pMap(paths, trash, {concurrency: os.cpus().length});

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"escape-string-applescript": "^2.0.0",
 		"fs-extra": "^0.30.0",
 		"globby": "^6.0.0",
+		"p-map": "^1.2.0",
 		"pify": "^3.0.0",
 		"run-applescript": "^3.0.0",
 		"uuid": "^3.1.0",

--- a/test.js
+++ b/test.js
@@ -102,16 +102,16 @@ test('directories', async t => {
 });
 
 test('tons of files', async t => {
-	const nFiles = 5000;
+	const FILE_COUNT = 5000;
 	const paths = [];
-	for (let i = 0; i < nFiles; i++) {
+	for (let i = 0; i < FILE_COUNT; i++) {
 		paths.push('file' + i);
 		fs.writeFileSync('file' + i, '');
 	}
 
 	await t.notThrows(m(paths));
 
-	for (let i = 0; i < nFiles; i++) {
+	for (let i = 0; i < FILE_COUNT; i++) {
 		t.false(fs.existsSync('file' + i));
 	}
 });

--- a/test.js
+++ b/test.js
@@ -102,15 +102,16 @@ test('directories', async t => {
 });
 
 test('tons of files', async t => {
+	const nFiles = 5000;
 	const paths = [];
-	for (let i = 0; i < 10000; i++) {
+	for (let i = 0; i < nFiles; i++) {
 		paths.push('file' + i);
 		fs.writeFileSync('file' + i, '');
 	}
 
-	await m(paths);
+	await t.notThrows(m(paths));
 
-	for (let i = 0; i < 10000; i++) {
+	for (let i = 0; i < nFiles; i++) {
 		t.false(fs.existsSync('file' + i));
 	}
 });

--- a/test.js
+++ b/test.js
@@ -101,7 +101,7 @@ test('directories', async t => {
 	t.false(fs.existsSync(321));
 });
 
-test('tons of files', async t => {
+(process.platform === 'linux' ? test : test.failing)('tons of files', async t => {
 	const FILE_COUNT = 5000;
 	const paths = [];
 	for (let i = 0; i < FILE_COUNT; i++) {

--- a/test.js
+++ b/test.js
@@ -101,6 +101,20 @@ test('directories', async t => {
 	t.false(fs.existsSync(321));
 });
 
+test('tons of files', async t => {
+	const paths = [];
+	for (let i = 0; i < 10000; i++) {
+		paths.push('file' + i);
+		fs.writeFileSync('file' + i, '');
+	}
+
+	await m(paths);
+
+	for (let i = 0; i < 10000; i++) {
+		t.false(fs.existsSync('file' + i));
+	}
+});
+
 if (process.platform === 'linux') {
 	test('create trashinfo', async t => {
 		t.plan(1);


### PR DESCRIPTION
This is a problem found in https://github.com/sindresorhus/trash-cli/issues/9. The problem isn't with [sindresorhus/trash-cli](https://github.com/sindresorhus/trash-cli) but with [sindresorhus/trash](https://github.com/sindresorhus/trash) since it's here where the call to the binary is made.

The solution was to use [sindresorhus/p-map](https://github.com/sindresorhus/p-map) and make single calls with limited concurrency.

This fix is relative to Linux. I tried fixing it on Windows too but I get `Incorrect value of args option` every time I call the binary which also is the reason the tests all crash on my machine (Windows 10 Pro, 64 bits, v1709, build 16299.19). I don't have access to a macOS machine.