### PR TITLE
Added bin directory option

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,8 @@ module.exports = (iterable, opts) => pTry(() => {
 	}
 
 	switch (process.platform) {
-		case 'darwin': return macos(paths);
-		case 'win32': return win(paths);
-		default: return linux(paths);
+		case 'darwin': return macos(paths, opts.binDir);
+		case 'win32': return win(paths, opts.binDir);
+		default: return linux(paths, opts.binDir);
 	}
 });

--- a/lib/macos.js
+++ b/lib/macos.js
@@ -9,7 +9,8 @@ const pify = require('pify');
 const olderThanMountainLion = Number(os.release().split('.')[0]) < 12;
 
 // Binary source: https://github.com/sindresorhus/macos-trash
-const bin = path.join(__dirname, 'macos-trash');
+//
+const bin = dir => path.join(dir, 'macos-trash');
 
 function legacy(paths) {
 	const pathStr = paths.map(x => `"${escapeStringApplescript(x)}"`).join(',');
@@ -30,10 +31,10 @@ tell app "Finder" to delete deleteList
 	});
 }
 
-module.exports = paths => {
+module.exports = (paths, dir=__dirname) => {
 	if (olderThanMountainLion) {
 		return legacy(paths);
 	}
 
-	return pify(execFile)(bin, paths);
+	return pify(execFile)(bin(dir), paths);
 };

--- a/lib/win.js
+++ b/lib/win.js
@@ -4,6 +4,6 @@ const execFile = require('child_process').execFile;
 const pify = require('pify');
 
 // Binary source: https://github.com/sindresorhus/recycle-bin
-const bin = path.join(__dirname, 'win-trash.exe');
+const bin = dir => path.join(dir, 'win-trash.exe');
 
-module.exports = paths => pify(execFile)(bin, paths);
+module.exports = (paths, dir=__dirname) => pify(execFile)(bin(dir), paths);


### PR DESCRIPTION
Added an optional bin path.

Found this necessary when being used with Electron (+ webpack) and I needed an alternative to `__dirname`, especially in production builds where node_modules are packaged with resources.

Similar to #48.

Thanks.