### PR TITLE
CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os:
   - linux
   - osx
+  - windows
 language: node_js
 node_js:
   - '11'

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Move files and folders to the trash
 
-[![Build Status](https://travis-ci.com/sindresorhus/trash.svg?branch=master)](https://travis-ci.com/sindresorhus/trash)
+[![Build Status](https://travis-ci.org/sindresorhus/trash.svg?branch=master)](https://travis-ci.org/sindresorhus/trash)
 
 Works on macOS, Linux, and Windows.
 

--- a/test.js
+++ b/test.js
@@ -48,7 +48,9 @@ test('glob', async t => {
 });
 
 test('no glob', async t => {
-	fs.writeFileSync('fixture-noglob*.js', '');
+	if (process.platform !== 'win32') {
+		fs.writeFileSync('fixture-noglob*.js', '');
+	}
 	fs.writeFileSync('fixture-noglob1.js', '');
 
 	await trash(['fixture-noglob*.js'], {glob: false});


### PR DESCRIPTION
- Enable Windows build in Travis CI
- Point badge back to `.org` (not migrated)
- Success: https://travis-ci.org/brandon93s/trash/builds/473896833

There isn't actually an AppVeyor config here, although [it was enabled](https://github.com/sindresorhus/make-dir/pull/8#issuecomment-450601345). Given the different code paths for each platform, I think it makes sense to enable in Travis.
