### PR TITLE
Fix glob for nested directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,8 @@ module.exports = (paths, options) => pTry(() => {
 
 				throw error;
 			}
-		});
+		})
+		.sort((a, b) => b.split(path.sep).length - a.split(path.sep).length);
 
 	if (paths.length === 0) {
 		return;

--- a/index.js
+++ b/index.js
@@ -25,6 +25,9 @@ module.exports = (paths, options) => pTry(() => {
 	}
 
 	paths = paths
+		.filter(filePath => !paths.some(
+			otherPath => filePath !== otherPath && path.dirname(filePath) === otherPath)
+		)
 		.map(filePath => path.resolve(filePath))
 		.filter(filePath => {
 			try {
@@ -36,8 +39,7 @@ module.exports = (paths, options) => pTry(() => {
 
 				throw error;
 			}
-		})
-		.sort((a, b) => b.split(path.sep).length - a.split(path.sep).length);
+		});
 
 	if (paths.length === 0) {
 		return;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 	"dependencies": {
 		"escape-string-applescript": "^2.0.0",
 		"globby": "^7.1.1",
+		"is-path-inside": "^2.0.0",
 		"make-dir": "^1.3.0",
 		"move-file": "^1.0.0",
 		"p-map": "^2.0.0",

--- a/test.js
+++ b/test.js
@@ -168,3 +168,31 @@ test('non-existent files', async t => {
 	t.false(fs.existsSync('fixture-enoent'));
 	await t.notThrowsAsync(trash('fixture-enoent'));
 });
+
+test('glob with nested directories', async t => {
+	const dir1 = 'foo';
+	const file1 = path.join('foo', 'bar.txt');
+	const file2 = path.join('foo', 'baz.txt');
+	const dir2 = path.join('foo', 'bar');
+	const dir3 = path.join('foo', 'baz');
+	const file3 = path.join(dir1, 'foo.txt');
+	const file4 = path.join(dir2, 'bar.txt');
+
+	fs.mkdirSync(dir1);
+	fs.mkdirSync(dir2);
+	fs.mkdirSync(dir3);
+	fs.writeFileSync(file1, '');
+	fs.writeFileSync(file2, '');
+	fs.writeFileSync(file3, '');
+	fs.writeFileSync(file4, '');
+	t.true(fs.existsSync(file1));
+	t.true(fs.existsSync(file2));
+	t.true(fs.existsSync(file3));
+	t.true(fs.existsSync(file4));
+
+	await trash(`${dir1}/**`, {glob: true});
+
+	t.false(fs.existsSync(dir1));
+	t.false(fs.existsSync(dir2));
+	t.false(fs.existsSync(dir3));
+});


### PR DESCRIPTION
Makes it possible to use the option `glob` with nested directories through sorting the filepaths by their depth before passing them to the `trash` function.

Fixes #75