### PR TITLE
linux: fix to comply with XDG, and show correct name in GNOME Trash

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -26,9 +26,10 @@ DeletionDate=${(new Date()).toISOString()}
 	// TODO: Use the `fs.mkdir` with `recursive` option when targeting Node.js 12.
 	await makeDir(path.dirname(trashInfoPath));
 
-	// Write the trash info file.  The filename should not exist already because
-	// it is a random UUID.  If it does, we will fail with error.code == 'EEXIST'.
-	// We need to create this first, because otherwise GnomeVFS will ignore it :D.
+	// Write the trash info file.
+	// The filename should not already exist because it's a random UUID. If it does,
+	// we will fail with `error.code == 'EEXIST'`. We need to create this first,
+	// because otherwise GnomeVFS will ignore it.
 	await pWriteFile(trashInfoPath, trashInfoData, {flag: 'wx'});
 
 	await moveFile(filePath, destination);

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -23,14 +23,15 @@ Path=${filePath.replace(/\s/g, '%20')}
 DeletionDate=${(new Date()).toISOString()}
 		`.trim();
 
-	await Promise.all([
-		moveFile(filePath, destination),
-		(async () => {
-			// TODO: Use the `fs.mkdir` with `recursive` option when targeting Node.js 12.
-			await makeDir(path.dirname(trashInfoPath));
-			await pWriteFile(trashInfoPath, trashInfoData);
-		})()
-	]);
+	// TODO: Use the `fs.mkdir` with `recursive` option when targeting Node.js 12.
+	await makeDir(path.dirname(trashInfoPath));
+
+	// Write the trash info file.  The filename should not exist already because
+	// it is a random UUID.  If it does, we will fail with error.code == 'EEXIST'.
+	// We need to create this first, because otherwise GnomeVFS will ignore it :D.
+	await pWriteFile(trashInfoPath, trashInfoData, {flag: 'wx'});
+
+	await moveFile(filePath, destination);
 
 	return {
 		path: destination,


### PR DESCRIPTION
> When trashing a file or directory, the implementation MUST create the
> corresponding file in $trash/info first. Moreover, it MUST try to do this
> in an atomic fashion, so that if two processes try to trash files with
> the same filename this will result in two different trash files. On
> Unix-line systems this is done by generating a filename, and then opening
> with O_EXCL.
>
> https://specifications.freedesktop.org/trash-spec/trashspec-latest.html

It looks like GnomeVFS was sanity-checking the timestamps.  So if you break
the rule and don't create the trashinfo file first, then GnomeVFS will
ignore it :-).

Fixes #56