### PR TITLE
Improve performance on Linux

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -8,28 +8,26 @@ const xdgTrashdir = require('xdg-trashdir');
 const pMap = require('p-map');
 const makeDir = require('make-dir');
 const moveFile = require('move-file');
+const {procfs} = require('@stroncium/procfs');
 
-const pWriteFile = promisify(fs.writeFile);
+const lstat = promisify(fs.lstat);
+const writeFile = promisify(fs.writeFile);
 
-const trash = async filePath => {
-	const trashDirectory = await xdgTrashdir(filePath);
+// Educated guess, values of 16 to 64 seem to be optimal for modern SSD, 8-16 and 64-128 can be a bit slower.
+// We should be ok as long as ssdCount <= cpuCount <= ssdCount*16.
+// For slower media this is not as important and we rely on OS handling it for us.
+const concurrency = os.cpus().length * 8;
+
+const trash = async (filePath, trashPaths) => {
 	const name = uuid.v4();
-	const destination = path.join(trashDirectory, 'files', name);
-	const trashInfoPath = path.join(trashDirectory, 'info', `${name}.trashinfo`);
+	const destination = path.join(trashPaths.filesPath, name);
+	const trashInfoPath = path.join(trashPaths.infoPath, `${name}.trashinfo`);
 
-	const trashInfoData = `
-[Trash Info]
-Path=${filePath.replace(/\s/g, '%20')}
-DeletionDate=${(new Date()).toISOString()}
-		`.trim();
+	const trashInfoData = `[Trash Info]\nPath=${filePath.replace(/\s/g, '%20')}\nDeletionDate=${(new Date()).toISOString()}`;
 
 	await Promise.all([
 		moveFile(filePath, destination),
-		(async () => {
-			// TODO: Use the `fs.mkdir` with `recursive` option when targeting Node.js 12.
-			await makeDir(path.dirname(trashInfoPath));
-			await pWriteFile(trashInfoPath, trashInfoData);
-		})()
+		writeFile(trashInfoPath, trashInfoData)
 	]);
 
 	return {
@@ -38,4 +36,33 @@ DeletionDate=${(new Date()).toISOString()}
 	};
 };
 
-module.exports = async paths => pMap(paths, trash, {concurrency: os.cpus().length});
+module.exports = async paths => {
+	const mountPointMap = new Map(procfs.processMountinfo().map(info => [info.devId, info.mountPoint]));
+	const trashPathsCache = new Map();
+
+	const getDeviceTrashPaths = async devId => {
+		let trashPathsPromise = trashPathsCache.get(devId);
+		if (trashPathsPromise === undefined) {
+			trashPathsPromise = (async () => {
+				const trashPath = await xdgTrashdir(mountPointMap.get(devId));
+				const paths = {
+					filesPath: path.join(trashPath, 'files'),
+					infoPath: path.join(trashPath, 'info')
+				};
+				// TODO: Use the `fs.mkdir` with `recursive` option when targeting Node.js 12.
+				await makeDir(paths.filesPath);
+				await makeDir(paths.infoPath);
+				return paths;
+			})();
+			trashPathsCache.set(devId, trashPathsPromise);
+		}
+
+		return trashPathsPromise;
+	};
+
+	return pMap(paths, async filePath => {
+		const stats = await lstat(filePath);
+		const trashPaths = await getDeviceTrashPaths(stats.dev);
+		return trash(filePath, trashPaths);
+	}, {concurrency});
+};

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"xdg"
 	],
 	"dependencies": {
+		"@stroncium/procfs": "^1.0.0",
 		"globby": "^7.1.1",
 		"is-path-inside": "^2.0.0",
 		"make-dir": "^3.0.0",


### PR DESCRIPTION
Fixes #79 

When actual move is performed(not just rename), the speed is mostly bound by IO, code details have minor effect, both for directories and for singular/multiple files.

When rename happens(majority of the cases), moving directory is almost the same as moving single file. So, I used simplistic benchmark for various number of files.

Before:
```
bench "1 file" took 0.186s
bench "10 files" took 0.222s
bench "100 files" took 0.619s
bench "1000 files" took 7.875s
bench "5000 files" took 80.94s
```

After:
```
bench "1 file" took 0.133s
bench "10 files" took 0.138s
bench "100 files" took 0.166s
bench "1000 files" took 1.719s
bench "5000 files" took 39.776s
```

Note, that the part that actually trashes files takes only around 0.6s out of `bench "5000 files" took 39.776s` case, remaining time is spent processing data prior to passing control to linux-specific code.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#79: Improve performance on Linux](https://issuehunt.io/repos/19789032/issues/79)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->