### PR TITLE
Update xdg-trashdir to ^3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"p-map": "^3.0.0",
 		"p-try": "^2.2.0",
 		"uuid": "^3.3.2",
-		"xdg-trashdir": "^2.1.1"
+		"xdg-trashdir": "^3.1.0"
 	},
 	"devDependencies": {
 		"ava": "^2.4.0",


### PR DESCRIPTION
Would help downstream packages avoid a depreciated cross-spawn-async warning.