### PR TITLE
Only require the necessary os library

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,6 @@ const trash = (paths, options) => pTry(() => {
 		return;
 	}
 
-
 	let trash;
 	if (process.platform === 'darwin') {
 		trash = require('./lib/macos');

--- a/index.js
+++ b/index.js
@@ -46,14 +46,14 @@ const trash = (paths, options) => pTry(() => {
 
 	switch (process.platform) {
 		case 'darwin':
-			const trash = require('./lib/macos');
-			return trash(paths);
+			const macos = require('./lib/macos');
+			return macos(paths);
 		case 'win32':
-			const trash = require('./lib/windows');
-			return trash(paths);
+			const windows = require('./lib/windows');
+			return windows(paths);
 		default:
-			const trash = require('./lib/linux');
-			return trash(paths);
+			const linux = require('./lib/linux');
+			return linux(paths);
 	}
 });
 

--- a/index.js
+++ b/index.js
@@ -44,17 +44,17 @@ const trash = (paths, options) => pTry(() => {
 		return;
 	}
 
-	switch (process.platform) {
-		case 'darwin':
-			const macos = require('./lib/macos');
-			return macos(paths);
-		case 'win32':
-			const windows = require('./lib/windows');
-			return windows(paths);
-		default:
-			const linux = require('./lib/linux');
-			return linux(paths);
+
+	let trash;
+	if (process.platform === 'darwin') {
+		trash = require('./lib/macos');
+	} else if (process.platform === 'win32') {
+		trash = require('./lib/windows');
+	} else {
+		trash = require('./lib/linux');
 	}
+
+	return trash(paths);
 });
 
 module.exports = trash;

--- a/index.js
+++ b/index.js
@@ -4,9 +4,6 @@ const path = require('path');
 const globby = require('globby');
 const pTry = require('p-try');
 const isPathInside = require('is-path-inside');
-const macos = require('./lib/macos');
-const linux = require('./lib/linux');
-const windows = require('./lib/windows');
 
 const trash = (paths, options) => pTry(() => {
 	paths = (typeof paths === 'string' ? [paths] : paths).map(path => String(path));
@@ -49,11 +46,14 @@ const trash = (paths, options) => pTry(() => {
 
 	switch (process.platform) {
 		case 'darwin':
-			return macos(paths);
+			const trash = require('./lib/macos');
+			return trash(paths);
 		case 'win32':
-			return windows(paths);
+			const trash = require('./lib/windows');
+			return trash(paths);
 		default:
-			return linux(paths);
+			const trash = require('./lib/linux');
+			return trash(paths);
 	}
 });
 


### PR DESCRIPTION
The [Linux lib](https://github.com/sindresorhus/trash/blob/main/lib/linux.js) has 30+ dependencies that should not be `require`d at all on other OSs. I imagine that this unnecessarily slows down other OS.

Perhaps the downside of the current code is that if you use `trash` as a library, the `require` code is called at every `trash()` call. If that's not ideal, I could look into "require once" logic.

Related: https://github.com/sindresorhus/meow/issues/104