### PR TITLE
Fix trashing on Linux

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -34,8 +34,8 @@ const trash = async (filePath, trashPaths) => {
 
 	const trashInfoData = `[Trash Info]\nPath=${filePath.replace(/\s/g, '%20')}\nDeletionDate=${getDeletionDate(new Date())}`;
 
-	await writeFile(trashInfoPath, trashInfoData)
-	await moveFile(filePath, destination)
+	await writeFile(trashInfoPath, trashInfoData);
+	await moveFile(filePath, destination);
 
 	return {
 		path: destination,

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -18,17 +18,24 @@ const writeFile = promisify(fs.writeFile);
 // For slower media this is not as important and we rely on OS handling it for us.
 const concurrency = os.cpus().length * 8;
 
+const pad = number => number < 10 ? '0' + number : number;
+
+const getDeletionDate = date => date.getFullYear() +
+	'-' + pad(date.getMonth() + 1) +
+	'-' + pad(date.getDate()) +
+	'T' + pad(date.getHours()) +
+	':' + pad(date.getMinutes()) +
+	':' + pad(date.getSeconds());
+
 const trash = async (filePath, trashPaths) => {
 	const name = uuid.v4();
 	const destination = path.join(trashPaths.filesPath, name);
 	const trashInfoPath = path.join(trashPaths.infoPath, `${name}.trashinfo`);
 
-	const trashInfoData = `[Trash Info]\nPath=${filePath.replace(/\s/g, '%20')}\nDeletionDate=${(new Date()).toISOString()}`;
+	const trashInfoData = `[Trash Info]\nPath=${filePath.replace(/\s/g, '%20')}\nDeletionDate=${getDeletionDate(new Date())}`;
 
-	await Promise.all([
-		moveFile(filePath, destination),
-		writeFile(trashInfoPath, trashInfoData)
-	]);
+	await writeFile(trashInfoPath, trashInfoData)
+	await moveFile(filePath, destination)
 
 	return {
 		path: destination,


### PR DESCRIPTION
Fixes #56 .

The changes are:
1. DeletionDate should be written like `%Y-%m-%dT%H:%M:%S` in the **local** time.
2. Write the trash info file completely before the file is moved to trash.

You can check the trash implementation in GNOME: https://gitlab.gnome.org/GNOME/glib/blob/glib-2-56/gio/glocalfile.c .

A code starting at line 2195 shows the appropriate style of trash info:
```c
  {
    time_t t;
    struct tm now;
    t = time (NULL);
    localtime_r (&t, &now);
    delete_time[0] = 0;
    strftime(delete_time, sizeof (delete_time), "%Y-%m-%dT%H:%M:%S", &now);
  }

  data = g_strdup_printf ("[Trash Info]\nPath=%s\nDeletionDate=%s\n",
			  original_name_escaped, delete_time);
```

As for the second change, a comment starting at line 2181 is helpful. This comment and discussion ( https://bugzilla.gnome.org/show_bug.cgi?id=749314 ) shows the appropriate order of moveFile and writeFile.
```c
  /* Write the full content of the info file before trashing to make
   * sure someone doesn't read an empty file.  See #749314
   */
```

I confirmed that the fixed code worked fine in Ubuntu 18.04. When I reverse the order of moveFile and writeFile in js, I always reproduce the hashed filename issue.