### PR TITLE
Harden Linux trash directories

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -57,8 +57,8 @@ module.exports = async paths => {
 					infoPath: path.join(trashPath, 'info')
 				};
 				// TODO: Use the `fs.mkdir` with `recursive` option when targeting Node.js 12.
-				await makeDir(paths.filesPath);
-				await makeDir(paths.infoPath);
+				await makeDir(paths.filesPath, {mode: 0o700});
+				await makeDir(paths.infoPath, {mode: 0o700});
 				return paths;
 			})();
 			trashPathsCache.set(devId, trashPathsPromise);


### PR DESCRIPTION
Create trashdirs with limited permissions to prevent information leaks.

The XDG trash spec is here:
https://specifications.freedesktop.org/trash-spec/trashspec-latest.html

It gives a main "home trash" directory, plus separate trashdirs per partition per user. The spec seems to be silent on permissions of these user trashdirs. Current behavior uses the default mode, which even with umask gets you world readable trashdirs. I think there's a risk here of exposing sensitive info. If you trash a sensitive file in a protected private directory where no one else could read it, it suddenly becomes visible to everyone in your unprotected trashdir.

This patch updates to create trashdirs with mode `0o700`, owner RWX. That prevents other users from reading your trash.

Current behavior gets world readable trashdirs:

```
[trash]$ ls -al /tmp | grep .Trash
[trash]$ touch /tmp/file
[trash]$ node -e "require('.')('/tmp/file')"
[trash]$ ls -al /tmp | grep .Trash
drwxrwxr-x  4 user user   80 Jun 10 17:02 .Trash-1000
[trash]$ ls -l /tmp/.Trash-1000
total 0
drwxrwxr-x 2 user user 60 Jun 10 17:02 files
drwxrwxr-x 2 user user 60 Jun 10 17:02 info
```

The update protects trashdirs to owner readable only:

```
[trash]$ ls -al /tmp | grep .Trash
[trash]$ touch /tmp/file
[trash]$ node -e "require('.')('/tmp/file')"
[trash]$ ls -al /tmp | grep .Trash
drwx------  4 user user   80 Jun 10 17:05 .Trash-1000
[trash]$ ls -l /tmp/.Trash-1000
total 0
drwx------ 2 user user 60 Jun 10 17:05 files
drwx------ 2 user user 60 Jun 10 17:05 info
```

I've tested this locally but I'm not sure a good way to get it into the test suite. You'd have to create a temporary partition without a trashdir to guarantee you get a creation. Or maybe intercept the partition listing module to inject a fake one. If you think it's important I can pursue this.