### PR TITLE
fix: ensure “first one wins” on mountPointMap on identical devId; fil…

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -40,15 +40,14 @@ const trash = async (filePath, trashPaths) => {
 export default async function linux(paths) {
 	// • filter irrelevant
 	// • “first one wins” if id comes along twice
-	const mountPointMap = 	procfs.processMountinfo()
-	.filter( m => !/^\/(snap|run|sys|proc|dev)($|\/)/.test(m.mountPoint))
-	.reduce((map, m) => {
-		console.log(m,"\n")
-		if (!map.has(m.devId)) {
-			map.set(m.devId, m.mountPoint)
+	const mountPointMap = new Map();
+
+	for (const m of Object.values(procfs.processMountinfo())
+		.filter(m => !/^\/(snap|run|sys|proc|dev)($|\/)/.test(m.mountPoint))) {
+		if (!mountPointMap.has(m.devId)) {
+			mountPointMap.set(m.devId, m.mountPoint);
 		}
-			return map
-	},new Map())
+	}
 
 	const trashPathsCache = new Map();
 

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -38,14 +38,18 @@ const trash = async (filePath, trashPaths) => {
 };
 
 export default async function linux(paths) {
-	// • filter irrelevant
-	// • “first one wins” if id comes along twice
 	const mountPointMap = new Map();
 
-	for (const m of Object.values(procfs.processMountinfo())
-		.filter(m => !/^\/(snap|run|sys|proc|dev)($|\/)/.test(m.mountPoint))) {
-		if (!mountPointMap.has(m.devId)) {
-			mountPointMap.set(m.devId, m.mountPoint);
+	for (const mountInfo of Object.values(procfs.processMountinfo())) {
+		// Filter out irrelevant drives (that start with `/snap`, `/run`...)
+		if (/^\/(snap|var\/snap|run|sys|proc|dev)($|\/)/.test(mountInfo.mountPoint)) {
+			continue;
+		}
+
+		// “first one wins” (aka does not get wiped,
+		// if a certain devId comes along multiple times
+		if (!mountPointMap.has(mountInfo.devId)) {
+			mountPointMap.set(mountInfo.devId, mountInfo.mountPoint);
 		}
 	}
 

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -41,13 +41,12 @@ export default async function linux(paths) {
 	const mountPointMap = new Map();
 
 	for (const mountInfo of Object.values(procfs.processMountinfo())) {
-		// Filter out irrelevant drives (that start with `/snap`, `/run`...)
+		// Filter out irrelevant drives (that start with `/snap`, `/run`, etc).
 		if (/^\/(snap|var\/snap|run|sys|proc|dev)($|\/)/.test(mountInfo.mountPoint)) {
 			continue;
 		}
 
-		// “first one wins” (aka does not get wiped,
-		// if a certain devId comes along multiple times
+		// Keep the first one if there are multiple `devId`.
 		if (!mountPointMap.has(mountInfo.devId)) {
 			mountPointMap.set(mountInfo.devId, mountInfo.mountPoint);
 		}

--- a/lib/linux.js
+++ b/lib/linux.js
@@ -38,7 +38,18 @@ const trash = async (filePath, trashPaths) => {
 };
 
 export default async function linux(paths) {
-	const mountPointMap = new Map(procfs.processMountinfo().map(info => [info.devId, info.mountPoint]));
+	// • filter irrelevant
+	// • “first one wins” if id comes along twice
+	const mountPointMap = 	procfs.processMountinfo()
+	.filter( m => !/^\/(snap|run|sys|proc|dev)($|\/)/.test(m.mountPoint))
+	.reduce((map, m) => {
+		console.log(m,"\n")
+		if (!map.has(m.devId)) {
+			map.set(m.devId, m.mountPoint)
+		}
+			return map
+	},new Map())
+
 	const trashPathsCache = new Map();
 
 	const getDeviceTrashPaths = async devId => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "trash",
-	"version": "8.1.0",
+	"version": "8.1.1",
 	"description": "Move files and folders to the trash",
 	"license": "MIT",
 	"repository": "sindresorhus/trash",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "trash",
-	"version": "8.1.1",
+	"version": "8.1.0",
 	"description": "Move files and folders to the trash",
 	"license": "MIT",
 	"repository": "sindresorhus/trash",


### PR DESCRIPTION
Original bug encountered (Ubuntu-MATE 22.04)

> Error: ENOENT: no such file or directory, mkdir '/var/snap/firefox/common/host-hunspell/.Trash-1000'

What became clear after some investigation was, that all my files (under `/common/...` and `/depot/...` I do like work outside my home dir 😬) have a devId of 64768 (nothing wrong with that…), but that that ID is given twice  (!) in the list coming from procfs!

```
64768 ext4 / / ['rw', 'relatime'] /dev/mapper/nvme0n1p6_crypt ['rw', 'errors=remount-ro']
...(other entries)
64768 ext4 /usr/share/hunspell /var/snap/firefox/common/host-hunspell ['ro', 'noexec', 'noatime'] /dev/mapper/nvme0n1p6_crypt ['rw', 'errors=remount-ro']
...(other entries)

```

The first one looks sane (my “root mount“) the second doesn't. Reboot didn't help by the way.

I did two fixes (each one having effect in my case)
• first one wins (won't get „wiped“), so far last one won. – of course it's a gamble, if the more correct mount is truly listed earlier
• filter out 'snaps' (and while we're at it several others, like `/proc`, `/proc/`, `/proc/something…` but not  `/procedures` (perhaps that's a valid mount, eh?)

The result looks good on my machine (essentially like [`df`](https://linux.die.net/man/1/df), not missing anything. (nb: I do have LUKS encryption, distinct boot partition and a Samba-share, all good, all there)


