### PR TITLE
docs: remove `$` from `trash-cli` install command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ Enable globbing when matching file paths.
 To install the [`trash`](https://github.com/sindresorhus/trash-cli) command, run:
 
 ```
-$ npm install --global trash-cli
+npm install --global trash-cli
 ```
 
 ## Info

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ Enable globbing when matching file paths.
 
 To install the [`trash`](https://github.com/sindresorhus/trash-cli) command, run:
 
-```
+```sh
 npm install --global trash-cli
 ```
 


### PR DESCRIPTION
GitHub code snippets have a copy feature, as seen in the screenshot below, which I use often and believe others do.

![Screenshot 2023-10-21 at 10 52 21](https://github.com/sindresorhus/trash/assets/30334776/49f14c66-12b0-45b8-b297-eab746088dbb)

If the copied shell command includes the `$` prefix, it will lead to an error when copied and pasted directly in the terminal like so:

![Screenshot 2023-10-21 at 10 53 37](https://github.com/sindresorhus/trash/assets/30334776/e0b09e42-42ae-4dfb-b207-dc4021e6f3aa)

Users will now have to edit the copied text again or type manually, which is a bad experience and a waste of the copy-snippet feature, which is great for installing packages and so. Hence, this PR removes the `$` prefix from the install `trash-cli` command. I believe this will remove the repetitive behaviour.

> Thanks for creating this, Sindre!