### PR TITLE
Encode .trashinfo Path with encodeURI as per XDG spec

### DIFF
--- a/lib/linux.js
+++ b/lib/linux.js
@@ -24,7 +24,7 @@ const trash = async (filePath, {filesPath, infoPath}) => {
 
 	const trashInfo = [
 		'[Trash Info]',
-		`Path=${filePath.replaceAll(/\s/g, '%20')}`,
+		`Path=${encodeURI(filePath)}`,
 		`DeletionDate=${formatDate(new Date())}`,
 	].join('\n');
 

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ npm install --global trash-cli
 ## Info
 
 On macOS, [`macos-trash`](https://github.com/sindresorhus/macos-trash) is used.\
-On Linux, the [XDG spec](https://standards.freedesktop.org/trash-spec/trashspec-1.0.html) is followed.\
+On Linux, the [XDG spec](https://specifications.freedesktop.org/trash/1.0/) is followed.\
 On Windows, [`recycle-bin`](https://github.com/sindresorhus/recycle-bin) is used.
 
 ## FAQ

--- a/test.js
+++ b/test.js
@@ -140,10 +140,10 @@ test('symlinks', async () => {
 
 if (process.platform === 'linux') {
 	test('create trashinfo', async () => {
-		fs.writeFileSync('f2', '');
+		fs.writeFileSync('f2 ^', '');
 
-		const info = `[Trash Info]\nPath=${path.resolve('f2')}`;
-		const files = await trash(['f2']);
+		const info = `[Trash Info]\nPath=${path.resolve(encodeURI('f2 ^'))}`;
+		const files = await trash(['f2 ^']);
 		const infoFile = fs.readFileSync(files[0].info, 'utf8');
 
 		assert.equal(infoFile.trim().indexOf(info.trim()), 0);


### PR DESCRIPTION
The [XDG trash spec](https://specifications.freedesktop.org/trash/1.0/) requires the .trashinfo Path= entry to be percent-encoded (RFC 2396).

The current implementation encodes only spaces, not other characters. This impacts files with special / non-ASCII characters in their names.

This change:

- Use encodeURI(filePath) to encoded paths properly (not just spaces).
- Updates the `create trashinfo` test to validate `'f2 ^'` instead of `'f2'`, introducing a special character in addition to space.
- Update README XDG spec link to the current official trash spec URL.