### PR TITLE
fix: switch to non-deprecated chunkify package

### DIFF
--- a/lib/chunked-exec.js
+++ b/lib/chunked-exec.js
@@ -1,7 +1,7 @@
+import chunkify from 'chunkify';
 import {promisify} from 'node:util';
 import {execFile} from 'node:child_process';
 import {fileURLToPath} from 'node:url';
-import chunkify from '@sindresorhus/chunkify';
 
 const pExecFile = promisify(execFile);
 

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
 		"xdg"
 	],
 	"dependencies": {
-		"@sindresorhus/chunkify": "^2.0.0",
 		"@stroncium/procfs": "^1.2.1",
+		"chunkify": "^2.0.0",
 		"globby": "^14.1.0",
 		"is-path-inside": "^4.0.0",
 		"move-file": "^3.1.0",


### PR DESCRIPTION
Switches from [`@sindresorhus/chunkify`](https://www.npmjs.com/package/@sindresorhus/chunkify) to [`chunkify`](https://www.npmjs.com/package/chunkify).

Fixes #135.